### PR TITLE
Favicon Rough Draft

### DIFF
--- a/lib/sensu-dashboard/views/layout.erb
+++ b/lib/sensu-dashboard/views/layout.erb
@@ -47,8 +47,8 @@
         <link rel="stylesheet" href="css/autoSuggest.css">
 
         <!-- Favicon: Set the sensu fan image from github as the favicon -->
-        <link rel="icon" href="https://github.com/sonian/sensu/raw/master/sensu-logo.png" type="image/x-icon">
-        <link rel="shortcut icon" href="https://github.com/sonian/sensu/raw/master/sensu-logo.png" type="image/x-icon">
+        <link rel="icon" href="/favicon.ico" type="image/x-icon">
+        <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 
 	<!-- all our JS is at the bottom of the page, except for Modernizr. -->
 	<script src="js/modernizr-1.7.min.js"></script>


### PR DESCRIPTION
Adding the sensu fan as a favicon (without favicons I can't find the tab!).  Or it could be the sonian favicon.  And the favicon could be local rather than on github.  Just putting this out there ;)
