### PR TITLE
Rich event output web UI

### DIFF
--- a/lib/sensu-dashboard/public/js/functions.js
+++ b/lib/sensu-dashboard/public/js/functions.js
@@ -135,6 +135,16 @@ function fetchEvents() {
         var m_event = m_events[status][a];
         var ccheck = m_event['client'] + m_event['check'];
 
+        // Attempt to parse event output as JSON, to enable
+        // rich event UI, such as hyperlinked 'url' attributes.
+        m_event['parsed_output'] = {};
+        try {
+          var parsed_output = jQuery.parseJSON(m_event['output']);
+          for (key in parsed_output) {
+            m_event['parsed_output'][key] = parsed_output[key];
+          }
+        } catch (err) {}
+
         $('#eventTemplate').tmpl(m_event).prependTo('table#events > tbody');
 
         $('tr#' + SHA1(ccheck)).click(function() {

--- a/lib/sensu-dashboard/views/event_templates.erb
+++ b/lib/sensu-dashboard/views/event_templates.erb
@@ -7,7 +7,13 @@
   {{/if}}
     <td id="client">${client}</td>
     <td id="check">${check}</td>
-    <td id="output">${output}</td>
+    <td id="output">
+    {{if parsed_output.message}}
+      ${parsed_output.message}
+    {{else}}
+      ${output}
+    {{/if}}
+    </td>
     <td id="status" style="display: none;">${status}</td>
   </tr>
 </script>
@@ -46,6 +52,16 @@
   <!--<div class="copy">Copy</div>-->
   <div style="clear: both;"></div>
 </div>
+{{if parsed_output.url}}
+<div class="event_detail_group">
+  <div class="event_detail">
+    <h1>URL</h1>
+    <p><a target="_blank" href="${parsed_output.url}">${parsed_output.url}</a></p>
+  </div>
+  <!--<div class="copy">Copy</div>-->
+  <div style="clear: both;"></div>
+</div>
+{{/if}}
 <div class="event_detail_group">
   <div class="event_detail">
     <h1>Occurrences</h1>


### PR DESCRIPTION
This patch attempts to parse check output as JSON, and, if applicable
render rich event detail to the web UI for events.

Specifically, if the check output is JSON and contains a 'url' attribute,
the url attribute will be rendered as a hyperlink in the event details
modal.  This is useful for checks that inherently have an associated URL,
i.e. an HTTP request check, or RPC failure that has an web UI, ala resque.

Additionally, this patch will attempt to render the 'message' attribute
of the output, if present, and fallback to rending the raw output. This
is necesary because raw json is hard to parse visually in the web UI.
