### PR TITLE
Optionally enabling dashboard page autorefresh.

### DIFF
--- a/lib/sensu-dashboard/views/layout.erb
+++ b/lib/sensu-dashboard/views/layout.erb
@@ -49,6 +49,10 @@
 	<!-- all our JS is at the bottom of the page, except for Modernizr. -->
 	<script src="js/modernizr-1.7.min.js"></script>
 
+  <% if $settings.dashboard.autorefresh %>
+  <!-- page autorefresh -->
+  <meta http-equiv="refresh" content="<%= $settings.dashboard.autorefresh %>">
+  <% end %>
 </head>
 
 <body>


### PR DESCRIPTION
If a $settings.dashboard.autorefresh value is specified, a
http-equiv="refresh" meta tag will be rendered, encouraging
modern browsers to refresh at the specified interval.

There is no validation of this setting, which typically
should be the refresh interval in seconds. An invalid
value should not cause any issues, other than not enabling
browser auto-refresh.
