### PR TITLE
Set a default empty hash for $api_options[:head]

### DIFF
--- a/lib/sensu-dashboard/app.rb
+++ b/lib/sensu-dashboard/app.rb
@@ -61,7 +61,7 @@ module Sensu
         end
         base.setup_process
         $api_url = 'http://' + $settings[:api][:host] + ':' + $settings[:api][:port].to_s
-        $api_options = {}
+        $api_options = {:head => {}}
         if $settings[:api][:user] && $settings[:api][:password]
           $api_options.merge!(:head => {:authorization => [$settings[:api][:user], $settings[:api][:password]]})
         end


### PR DESCRIPTION
This prevents an error setting `$api_options[:head]["Accept"]` later in the code, if there was no auth set.
