### PR TITLE
fix null object error when an event is removed between checks

### DIFF
--- a/lib/sensu-dashboard/assets/javascripts/views/list.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/views/list.coffee
@@ -32,7 +32,7 @@ namespace "SensuDashboard.Views", (exports) ->
           @renderItem(item)
 
     renderEmpty: (collection = @collection) ->
-      if collection.isEmpty()
+      if !collection?
         tmpl = HandlebarsTemplates["empty_list"]
         @$el.html(tmpl())
         true


### PR DESCRIPTION
as discussed on irc, i believe this fixes an error that causes refreshing the events table to stop working if an event is removed between updates.

the error in the console is:
`Uncaught TypeError: Object #<Event> has no method 'isEmpty'`
