### PR TITLE
Compressing modal views.

### DIFF
--- a/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
@@ -7,19 +7,22 @@
 </div>
 <div class="modal-body">
   <h3 class="section_title">event data</h3>
+  <div class="well">
   {{#each event}}
-    <div class="well">
-      <h5>{{@key}}</h5>
-      <span class="modal_value">{{#if this}}{{this}}{{else}}false/nil{{/if}}</span>
-    </div>
+    {{#if this}}
+      <strong>{{@key}}</strong> <span class="modal_value">{{this}}</span><br/>
+    {{/if}}
   {{/each}}
+  </div>
+
   <h3 class="section_title">client data</h3>
+  <div class="well">
   {{#each client}}
-    <div class="well">
-      <h5>{{@key}}</h5>
-      <span class="modal_value">{{#if this}}{{this}}{{else}}false/nil{{/if}}</span>
-    </div>
+    {{#if this}}
+      <strong>{{@key}}</strong> <span class="modal_value">{{this}}</span>
+    {{/if}}
   {{/each}}
+  </div>
 </div>
 <div class="modal-footer">
   <button id="silence_client" class="btn btn-danger">


### PR DESCRIPTION
The current modal view for events is rather long, and hard to quickly scan for information.

This pull request changes two aspects.  Firstly, it puts all of the key/value data into a single 'well' div, which makes it much easier to scan.  Secondly, it does not show 'nil/false' data elements.  Data that evals to false could be valid, but this opts for simplicity and clarity over verbosity (if there are strong feelings I'd remove this to keep the single-well element).
# booyeah
