### PR TITLE
Adding helper to truncate event list-item 'output'.

### DIFF
--- a/lib/sensu-dashboard/assets/javascripts/handlebars_helpers.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/handlebars_helpers.coffee
@@ -1,2 +1,8 @@
 Handlebars.registerHelper "selected", (selected) ->
   return if selected then "checked" else ""
+
+Handlebars.registerHelper "truncate", (text, length) ->
+  truncated = text.substring(0, length)
+  if text.length > length
+    truncated = truncated + "..."
+  return truncated

--- a/lib/sensu-dashboard/assets/javascripts/templates/events/list_item.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/events/list_item.hbs
@@ -15,4 +15,4 @@
   {{/if}}
   {{check}}
 </td>
-<td class="output">{{output}}</td>
+<td class="output">{{truncate output 90}}</td>


### PR DESCRIPTION
This implements a naive and arbitrary truncation of the event 'output' attribute.  This creates a nice layout for the current even list-items, while the full output is still available in the modal.

Limiting to 90 characters seems about right.  And by that I mean that it fit perfectly on my laptop.

UPDATE:  Here is a CSS implementation that seems OK.  I guess I don't like hard-coded pixel heights, but this does the trick, and is more adaptable to different screen widths (Rather than the arbitrary character length).

What do you think?

```
td.output {
  line-height: 28px;
  height: 20px;
  overflow: hidden;
  display: block;
}
```
