### PR TITLE
documentation link referenced non-existing url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A front-end dashboard for the Sensu monitoring framework.
 
 ## Documentation
-  Please refer to the [Sensu Wiki](https://github.com/sensu/sensu-dashboard/wiki).
+  Please refer to the [Sensu Wiki](https://github.com/sensu/sensu/wiki).
 
 ## License
   Sensu is released under the [MIT license](https://raw.github.com/sensu/sensu-dashboard/master/MIT-LICENSE.txt).


### PR DESCRIPTION
original url points to a wiki that doesn't exist. let's point to some that does exist.
