### PR TITLE
Stop dashboard process erroring out after 1st page load when api down

### DIFF
--- a/lib/sensu-dashboard/server.rb
+++ b/lib/sensu-dashboard/server.rb
@@ -207,7 +207,9 @@ module Sensu::Dashboard
 
       multi.callback do
         empty_body = routes.detect do |route|
-          multi.responses[:callback][route].response == ""
+          if multi.responses[:callback][route]
+            multi.responses[:callback][route].response == ""
+          end
         end
 
         unless multi.responses[:errback].keys.count > 0 || empty_body


### PR DESCRIPTION
This stops the dashboards process from dying when the API is down/offline. Page will just reload with error message each time.
