### PR TITLE
Linkify URLish modal values for event and client data.

### DIFF
--- a/lib/sensu-dashboard/assets/javascripts/handlebars_helpers.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/handlebars_helpers.coffee
@@ -9,3 +9,11 @@ Handlebars.registerHelper "truncate", (text, length) ->
 
 Handlebars.registerHelper "strip", (text) ->
   return text.toString().replace(/^\s\s*/, '').replace(/\s\s*$/, '')
+
+Handlebars.registerHelper "linkify", (text) ->
+  exp = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig
+  return text.toString().replace(exp,"<a href='$1'>$1</a>")
+
+Handlebars.registerHelper "modalValue", (text) ->
+  linkified = Handlebars.helpers.linkify(text)
+  return Handlebars.helpers.strip(linkified)

--- a/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
@@ -10,7 +10,7 @@
   <div class="well">
   {{#each event}}
     {{#if this}}
-      <strong>{{@key}}</strong> <span class="modal_value">{{strip this}}</span><br/>
+      <strong>{{@key}}</strong> <span class="modal_value">{{{modalValue this}}}</span><br/>
     {{/if}}
   {{/each}}
   </div>
@@ -19,7 +19,7 @@
   <div class="well">
   {{#each client}}
     {{#if this}}
-      <strong>{{@key}}</strong> <span class="modal_value">{{this}}</span><br />
+      <strong>{{@key}}</strong> <span class="modal_value">{{{modalValue this}}}</span><br />
     {{/if}}
   {{/each}}
   </div>


### PR DESCRIPTION
This replaces URLs with HTML markup to linkify event and client values.  This is helpful for specifying client URLs (metrics, logstreams, etc) and event data (playbook, relevant metrics, etc).

Screenshot:
https://www.evernote.com/shard/s213/res/f6234bec-c11e-4a48-ab55-6474fd271980
