### PR TITLE
Fix basic auth realm syntax

### DIFF
--- a/lib/sensu-dashboard/server.rb
+++ b/lib/sensu-dashboard/server.rb
@@ -129,7 +129,7 @@ module Sensu::Dashboard
     helpers do
       def protected!
         unless authorized?
-          response['WWW-Authenticate'] = %(Basic realm='Restricted Area')
+          response['WWW-Authenticate'] = %(Basic realm="Restricted Area")
           throw(:halt, [401, 'Not authorized\n'])
         end
       end


### PR DESCRIPTION
A basic auth realm parameter is a quoted-string [RFC2617](http://www.ietf.org/rfc/rfc2617.txt)§1.2; a
quoted-string takes double quotes, not single quotes [RFC2616](http://www.ietf.org/rfc/rfc2616.txt)§2.2.
