### PR TITLE
Add dashboard config api section to override host/port

### DIFF
--- a/lib/sensu-dashboard/server.rb
+++ b/lib/sensu-dashboard/server.rb
@@ -60,7 +60,7 @@ module Sensu::Dashboard
         $dashboard_settings = settings[:dashboard] || Hash.new
         $dashboard_settings[:port] ||= 8080
         $dashboard_settings[:poll_frequency] ||= 10
-        $api_settings = settings[:api] || Hash.new
+        $api_settings = $dashboard_settings[:api] || settings[:api] || Hash.new
         $api_settings[:host] ||= 'localhost'
         $api_settings[:port] ||= 4567
         unless $dashboard_settings[:port].is_a?(Integer)


### PR DESCRIPTION
By default, sensu dashboard takes the api host and port from the api configuration file.  

If the dashboard and api are running on the same box, and you use a web proxy, then the api config will have 'host: localhost'.  However, this will obviously break for the dashboard when run remotely.

This patch allows you to specify an explicit api host and port for the dashboard to connect to, e.g.:

``` JSON
{
  "dashboard": {
    "bind": "127.0.0.1",
    "port": 8080,
    "api": {
      "host": "api.web-proxy.example.com", 
      "port": 80
    }
  }
}
```

No change in previous behaviour should be expected if this api subsection isn't defined.
