### PR TITLE
Adding expire option for stashes on clients and checks

### DIFF
--- a/lib/sensu-dashboard/assets/javascripts/models/client.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/models/client.coffee
@@ -7,6 +7,7 @@ namespace "SensuDashboard.Models", (exports) ->
       address: null
       subscriptions: []
       timestamp: 0
+      expire: 300
 
     idAttribute: "name"
 
@@ -28,6 +29,7 @@ namespace "SensuDashboard.Models", (exports) ->
       @errorCallback = options.error
       stash = SensuDashboard.Stashes.create({
         path: @get("silence_path")
+        expire: options.expire_time
         content: { timestamp: Math.round(new Date().getTime() / 1000) }}, {
         success: (model, response, opts) =>
           @successCallback.apply(this, [this, response]) if @successCallback

--- a/lib/sensu-dashboard/assets/javascripts/models/event.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/models/event.coffee
@@ -10,6 +10,7 @@ namespace "SensuDashboard.Models", (exports) ->
       status: 3
       flapping: false
       issued: "0000-00-00T00:00:00Z"
+      expire: 300
 
     initialize: ->
       @set(id: "#{@get("client")}/#{@get("check")}")
@@ -58,6 +59,7 @@ namespace "SensuDashboard.Models", (exports) ->
       @errorCallback = options.error
       stash = SensuDashboard.Stashes.create({
         path: @get("silence_path")
+        expire: options.expire_time
         content: { timestamp: Math.round(new Date().getTime() / 1000) }}, {
         success: (model, response, opts) =>
           @successCallback.apply(this, [this, response]) if @successCallback

--- a/lib/sensu-dashboard/assets/javascripts/models/stash.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/models/stash.coffee
@@ -5,6 +5,7 @@ namespace "SensuDashboard.Models", (exports) ->
     defaults:
       path: "silence"
       content: {}
+      expire: 300
 
     idAttribute: "path"
 

--- a/lib/sensu-dashboard/assets/javascripts/models/stash.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/models/stash.coffee
@@ -33,3 +33,14 @@ namespace "SensuDashboard.Models", (exports) ->
         error: (model, xhr, opts) =>
           @errorCallback.apply(this, [model, xhr, opts]) if @errorCallback
 
+    updateStash: (options = {}) =>
+      @successCallback = options.success
+      @errorCallback = options.error
+      stash = SensuDashboard.Stashes.create({
+        path: options.silence_path
+        expire: options.expire_time
+        content: { timestamp: Math.round(new Date().getTime() / 1000) }}, {
+        success: (model, response, opts) =>
+          @successCallback.apply(this, [this, response]) if @successCallback
+        error: (model, xhr, opts) =>
+          @errorCallback.apply(this, [this, xhr, opts]) if @errorCallback})

--- a/lib/sensu-dashboard/assets/javascripts/templates/clients/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/clients/modal.hbs
@@ -14,15 +14,19 @@
   {{/each}}
 </div>
 <div class="modal-footer">
-  <button id="silence_client" class="btn btn-danger">
-    {{#if silenced}}
+  {{#if silenced}}
+    <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-off icon-white" />
       <span>&nbsp;Un-silence Client</span>
-    {{else}}
+    </button>
+  {{else}}
+    Expire (seconds): <input id="silence_client_expire" type="text" value="{{expire}}" />
+    <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-up icon-white" />
       <span>&nbsp;Silence Client</span>
-    {{/if}}
-  </button>
+    </button>
+  {{/if}}
+  <br/>
   <button id="remove_client" class="btn btn-danger">
       <i class="icon-remove icon-white" />
       <span>&nbsp;Remove Client</span>

--- a/lib/sensu-dashboard/assets/javascripts/templates/clients/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/clients/modal.hbs
@@ -14,13 +14,14 @@
   {{/each}}
 </div>
 <div class="modal-footer">
+  Expire:
+  <input style="width:50px;" id="silence_client_expire" type="number" value="{{expire}}" />
   {{#if silenced}}
     <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-off icon-white" />
       <span>&nbsp;Un-silence Client</span>
     </button>
   {{else}}
-    Expire (seconds): <input id="silence_client_expire" type="text" value="{{expire}}" />
     <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-up icon-white" />
       <span>&nbsp;Silence Client</span>

--- a/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
@@ -25,24 +25,30 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button id="silence_client" class="btn btn-danger">
-    {{#if client.silenced}}
+  {{#if client.silenced}}
+    <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-off icon-white" />
       <span>&nbsp;Un-silence Client</span>
-    {{else}}
+    </button>
+  {{else}}
+    Expire (seconds): <input id="silence_client_expire" type="text" value="{{client.expire}}" />
+    <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-up icon-white" />
       <span>&nbsp;Silence Client</span>
-    {{/if}}
-  </button>
-  <button id="silence_check" class="btn btn-danger">
-    {{#if event.silenced}}
+    </button>
+  {{/if}}
+  {{#if event.silenced}}
+    <button id="silence_check" class="btn btn-danger">
       <i class="icon-volume-off icon-white" />
       <span>&nbsp;Un-silence Check</span>
-    {{else}}
+    </button>
+  {{else}}
+    Expire (seconds): <input id="silence_check_expire" type="text" value="{{event.expire}}" />
+    <button id="silence_check" class="btn btn-danger">
       <i class="icon-volume-up icon-white" />
       <span>&nbsp;Silence Check</span>
-    {{/if}}
-  </button>
+    </button>
+  {{/if}}
   <button id="resolve_check" class="btn btn-danger">
     <i class="icon-ok icon-white" />
     <span>&nbsp;Resolve</span>

--- a/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/events/modal.hbs
@@ -25,30 +25,35 @@
   </div>
 </div>
 <div class="modal-footer">
+  Expire:
+  <input style="width:50px;" id="silence_client_expire" type="number" value="{{client.expire}}" />
   {{#if client.silenced}}
     <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-off icon-white" />
       <span>&nbsp;Un-silence Client</span>
     </button>
   {{else}}
-    Expire (seconds): <input id="silence_client_expire" type="text" value="{{client.expire}}" />
     <button id="silence_client" class="btn btn-danger">
       <i class="icon-volume-up icon-white" />
       <span>&nbsp;Silence Client</span>
     </button>
   {{/if}}
+  <br />
+
+  Expire:
+  <input style="width:50px;" id="silence_check_expire" type="number" value="{{event.expire}}" />
   {{#if event.silenced}}
     <button id="silence_check" class="btn btn-danger">
       <i class="icon-volume-off icon-white" />
       <span>&nbsp;Un-silence Check</span>
     </button>
   {{else}}
-    Expire (seconds): <input id="silence_check_expire" type="text" value="{{event.expire}}" />
     <button id="silence_check" class="btn btn-danger">
       <i class="icon-volume-up icon-white" />
       <span>&nbsp;Silence Check</span>
     </button>
   {{/if}}
+  <br />
   <button id="resolve_check" class="btn btn-danger">
     <i class="icon-ok icon-white" />
     <span>&nbsp;Resolve</span>

--- a/lib/sensu-dashboard/assets/javascripts/templates/stashes/list.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/stashes/list.hbs
@@ -3,6 +3,7 @@
     <tr>
       <th></th>
       <th class="col_path">Path</th>
+      <th class="col_path">Expire</th>
       <th class="col_keys">Keys</th>
     </tr>
   </thead>

--- a/lib/sensu-dashboard/assets/javascripts/templates/stashes/list_item.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/stashes/list_item.hbs
@@ -2,4 +2,5 @@
   <input type="checkbox" {{selected selected}}/>
 </td>
 <td class="path">{{path}}</td>
+<td class="path">{{expire}}</td>
 <td class="keys">{{key_list}}</td>

--- a/lib/sensu-dashboard/assets/javascripts/templates/stashes/modal.hbs
+++ b/lib/sensu-dashboard/assets/javascripts/templates/stashes/modal.hbs
@@ -10,6 +10,10 @@
     <h5>Path</h5>
     <span class="modal_value">{{path}}</span>
   </div>
+  <div class="well">
+    <h5>Expire</h5>
+    <span class="modal_value">{{expire}}</span>
+  </div>
   {{#each content}}
     <div class="well">
       <h5>{{@key}}</h5>
@@ -18,6 +22,14 @@
   {{/each}}
 </div>
 <div class="modal-footer">
+  <input id="silence_path" type="hidden" value="{{path}}" />
+  Expire:
+  <input style="width:50px;" id="stash_expire" type="number" value="{{expire}}" />
+  <button id="update_stash" class="btn btn-danger">
+    <i class="icon-volume-off icon-white" />
+    <span>&nbsp;Save Change</span>
+  </button>
+  <br />
   <button id="remove_stash" class="btn btn-danger">
     <i class="icon-remove icon-white" />
     <span>&nbsp;Remove</span>

--- a/lib/sensu-dashboard/assets/javascripts/views/clients/modal.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/views/clients/modal.coffee
@@ -31,6 +31,7 @@ namespace "SensuDashboard.Views.Clients", (exports) ->
         parent = $(ev.target)
       icon = parent.find("i").first()
       text = parent.find("span").first()
+      expire_time = parseInt($("#silence_client_expire").val(), 10)
       if @model.get("silenced")
         icon.removeClass("icon-volume-off").addClass("icon-spinner icon-spin")
         text.html("Un-silencing...")
@@ -50,6 +51,7 @@ namespace "SensuDashboard.Views.Clients", (exports) ->
         icon.removeClass("icon-volume-up").addClass("icon-spinner icon-spin")
         text.html("Silencing...")
         @model.silence
+          expire_time: expire_time
           success: (model) ->
             client_name = model.get("name")
             toastr.success("Silenced client #{client_name}."

--- a/lib/sensu-dashboard/assets/javascripts/views/events/modal.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/views/events/modal.coffee
@@ -38,6 +38,7 @@ namespace "SensuDashboard.Views.Events", (exports) ->
         parent = $(ev.target)
       icon = parent.find("i").first()
       text = parent.find("span").first()
+      expire_time = parseInt($("#silence_client_expire").val(), 10)
       if @client.get("silenced")
         icon.removeClass("icon-volume-off").addClass("icon-spinner icon-spin")
         text.html("Un-silencing...")
@@ -57,6 +58,7 @@ namespace "SensuDashboard.Views.Events", (exports) ->
         icon.removeClass("icon-volume-up").addClass("icon-spinner icon-spin")
         text.html("Silencing...")
         @client.silence
+          expire_time: expire_time
           success: (model) ->
             client_name = model.get("name")
             toastr.success("Silenced client #{client_name}."
@@ -76,6 +78,7 @@ namespace "SensuDashboard.Views.Events", (exports) ->
         parent = $(ev.target)
       icon = parent.find("i").first()
       text = parent.find("span").first()
+      expire_time = parseInt($("#silence_check_expire").val(), 10)
       if @event.get("silenced")
         icon.removeClass("icon-volume-off").addClass("icon-spinner icon-spin")
         text.html("Un-silencing...")
@@ -95,6 +98,7 @@ namespace "SensuDashboard.Views.Events", (exports) ->
         icon.removeClass("icon-volume-up").addClass("icon-spinner icon-spin")
         text.html("Silencing...")
         @event.silence
+          expire_time: expire_time
           success: (model) ->
             check_name = model.get("check")
             toastr.success("Silenced check #{check_name}."

--- a/lib/sensu-dashboard/assets/javascripts/views/stashes/list_item.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/views/stashes/list_item.coffee
@@ -15,6 +15,7 @@ namespace "SensuDashboard.Views.Stashes", (exports) ->
       template_data =
         selected: @model.get("selected"),
         path: @model.get("path"),
+        expire: @model.get("expire"),
         key_list: Object.keys(@model.get("content")).join(", ")
       @$el.html(@template(template_data))
       this

--- a/lib/sensu-dashboard/assets/javascripts/views/stashes/modal.coffee
+++ b/lib/sensu-dashboard/assets/javascripts/views/stashes/modal.coffee
@@ -5,6 +5,7 @@ namespace "SensuDashboard.Views.Stashes", (exports) ->
     name: "stashes/modal"
 
     events:
+      "click #update_stash": "updateStash"
       "click #remove_stash": "removeStash"
 
     initialize: ->
@@ -43,4 +44,26 @@ namespace "SensuDashboard.Views.Stashes", (exports) ->
           toastr.error("Error removing stash #{stash_name}.
             The stash may already be removed or Sensu API is down."
             , "Removal Error!"
+            , { positionClass: "toast-bottom-right" })
+
+    updateStash: (ev) ->
+      tag_name = $(ev.target).prop("tagName")
+      if tag_name == "SPAN" || tag_name == "I"
+        parent = $(ev.target).parent()
+      else
+        parent = $(ev.target)
+      text = parent.find("span").first()
+      silence_path = $("#silence_path").val()
+      expire_time = parseInt($("#stash_expire").val(), 10)
+      text.html("Updating...")
+      @model.updateStash
+        expire_time: expire_time
+        silence_path: silence_path
+        success: (model) ->
+          toastr.success("Updated stash #{silence_path}."
+            , "Success!"
+            , { positionClass: "toast-bottom-right" })
+        error: (model, xhr, opts) ->
+          toastr.error("Error updating stash#{silence_path}."
+            , "Updating Error!"
             , { positionClass: "toast-bottom-right" })


### PR DESCRIPTION
The stashes page lists the expire times for stashes.  The modal boxes have boxes to set the expire for either silence check or silence client.
It's ugly, but it's functional.  I'm not quite sure how to get the formatting pretty, but I'm definitely open to suggestions.
I'm not quite sure what to do with the "Silence checked clients" and "Silence checked checks" functionality, other than use the default expire values for each.  The defaults are set in the models.
